### PR TITLE
Update for new getrusage

### DIFF
--- a/lib/P5times.pm6
+++ b/lib/P5times.pm6
@@ -3,12 +3,13 @@ unit module P5times:ver<0.0.1>;
 
 sub times() is export {
     use nqp;
-    my \rusage = nqp::getrusage();
+    my int @rusage;
+    nqp::getrusage(@rusage);
     (
-      nqp::atpos_i(rusage, nqp::const::RUSAGE_UTIME_SEC) * 1000000
-        + nqp::atpos_i(rusage, nqp::const::RUSAGE_UTIME_MSEC),
-      nqp::atpos_i(rusage, nqp::const::RUSAGE_STIME_SEC) * 1000000
-        + nqp::atpos_i(rusage, nqp::const::RUSAGE_STIME_MSEC),
+      nqp::atpos_i(@rusage, nqp::const::RUSAGE_UTIME_SEC) * 1000000
+        + nqp::atpos_i(@rusage, nqp::const::RUSAGE_UTIME_MSEC),
+      nqp::atpos_i(@rusage, nqp::const::RUSAGE_STIME_SEC) * 1000000
+        + nqp::atpos_i(@rusage, nqp::const::RUSAGE_STIME_MSEC),
       0,
       0
     )


### PR DESCRIPTION
This fixes the crash, but I still have one test failing (on Linux). No idea if it was working in the past.

```
$ prove6l
./t/01-basic.t .. 
1..10
ok 1 - is &times imported?
ok 2 - is &times externally NOT accessible?
ok 3 - did we get some user CPU
ok 4 - did we get some system CPU
ok 5 - did we get no child user CPU
ok 6 - did we get no child system CPU
ok 7 - did we get more user CPU
not ok 8 - did we get more system CPU
# Failed test 'did we get more system CPU'
# at ./t/01-basic.t line 18
ok 9 - did we get no child user CPU
ok 10 - did we get no child system CPU
# Looks like you failed 1 test of 10
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/10 subtests 

Test Summary Report
-------------------
./t/01-basic.t (Wstat: 256 Tests: 10 Failed: 1)
  Failed test:  8
  Non-zero exit status: 1
Files=1, Tests=10,  1 wallclock secs ( 0.03 usr  0.00 sys +  0.96 cusr  0.14 csys =  1.13 CPU)
Result: FAIL
```